### PR TITLE
Optimizing red-black in-order traversal.

### DIFF
--- a/Source/PowerCollections/Util.cs
+++ b/Source/PowerCollections/Util.cs
@@ -116,5 +116,37 @@ namespace Wintellect.PowerCollections
             else
                 return equalityComparer.GetHashCode(item);
         }
+
+        /// <summary>
+        /// Lookup table for <see cref="LogBase2"/>.
+        /// </summary>
+        /// <remarks>
+        /// https://graphics.stanford.edu/~seander/bithacks.html#IntegerLogDeBruijn
+        /// </remarks>
+        private static readonly int[] MultiplyDeBruijnBitPosition =
+        {
+            0, 9, 1, 10, 13, 21, 2, 29, 11, 14, 16, 18, 22, 25, 3, 30,
+            8, 12, 20, 28, 15, 17, 24, 7, 19, 27, 23, 6, 26, 5, 4, 31
+        };
+
+        /// <summary>
+        /// Gets the log-base-2 of a positive integer value.
+        /// </summary>
+        /// <param name="v">Value whose log-base-2 to calculate.</param>
+        /// <returns>The log-base-2 of the value.</returns>
+        /// <remarks>
+        /// https://graphics.stanford.edu/~seander/bithacks.html#IntegerLogDeBruijn
+        /// </remarks>
+        public static int LogBase2(uint v)
+        {
+            // first round down to one less than a power of 2
+            v |= v >> 1;
+            v |= v >> 2;
+            v |= v >> 4;
+            v |= v >> 8;
+            v |= v >> 16;
+
+            return MultiplyDeBruijnBitPosition[unchecked((uint)(v * 0x07C4ACDDUL)) >> 27];
+        }
     }
 }


### PR DESCRIPTION
In-order traversal of red-black trees can have a significant impact on union overlay operations in NTS, taking up more than 13% of the total CPU samples in some runs I've done.  Rewriting it like this, its impact vanishes completely.

As much as I desire to remove PowerCollections from NTS where it's possible to do, there's no getting away from PowerCollections Red-Black trees for PCL targets without more rewrites on the NTS side.

My version of UtilTests.cs that exercises `Util.LogBase2` (requires either C# 6 or annoying work I don't really feel like doing): https://gist.github.com/airbreather/7128d4dc74a76b098636.  Of course, all the tests pass or I wouldn't have submitted this.

I also ran all the existing tests, and tried with a few different variants on the changes to make sure the tests covered the non-obvious things in RedBlack.cs (i.e., the stuff it does on top of a "traditional" in-order traversal):
- without these changes, all tests pass
- with these changes as-written, all tests pass
- moving `stack.Push(current)` below the break, some tests fail.
- swapping the `>` / `<` in the short-circuit checks, some tests fail.  I actually made this mistake [initially](https://gist.github.com/airbreather/8b8544f9c4babcc490ba#file-range-cs-L38) in that gist I linked on NetTopologySuite/NetTopologySuite#73.

I don't know what the game plan is for "Binaries" or "PowerCollections.zip", so I've left them alone for now.
